### PR TITLE
speedup optimization and optimize specific lengths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "voronoi_planner/tinyspline"]
-	path = splined_voronoi/tinyspline
-	url = https://github.com/msteinbeck/tinyspline
 [submodule "voronoi_planner/nlopt"]
 	path = splined_voronoi/nlopt
 	url = https://github.com/stevengj/nlopt

--- a/setup.sh
+++ b/setup.sh
@@ -4,16 +4,7 @@ cmake .
 make
 sudo make install
 
-cd ..
-
-cd tinyspline/
-mkdir build
-cd build
-cmake -DBUILD_SHARED_LIBS=True ..
-cmake --build .
-sudo cmake --build . --target install
-
-cd ../../..
+cd ../..
 rosdep update
 rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 catkin build

--- a/splined_voronoi/splined_voronoi/CMakeLists.txt
+++ b/splined_voronoi/splined_voronoi/CMakeLists.txt
@@ -23,8 +23,8 @@ find_package(OpenCV)
 
 find_package(Eigen3 REQUIRED)
 
-set(tinysplinecxx_DIR "/usr/local/lib64/cmake/tinysplinecxx/")
-find_package(tinysplinecxx)
+# set(tinysplinecxx_DIR "/usr/local/lib64/cmake/tinysplinecxx/")
+# find_package(tinysplinecxx)
 
 # set(nlopt_DIR "/usr/local/lib/cmake/nlopt/")
 find_package(NLopt)
@@ -76,7 +76,7 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
-  ${TINYSPLINECXX_INCLUDE_DIRS}
+  # ${TINYSPLINECXX_INCLUDE_DIRS}
   ${NLOPT_INCLUDE_DIRS}
 )
 
@@ -85,7 +85,7 @@ add_library(splined_voronoi src/splined_voronoi_planner.cpp src/path_planning sr
 target_link_libraries(splined_voronoi
   ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
-  ${TINYSPLINECXX_LIBRARIES}
+  # ${TINYSPLINECXX_LIBRARIES}
   ${NLOPT_LIBRARIES}
 )
 add_dependencies(splined_voronoi ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)

--- a/splined_voronoi/splined_voronoi/CMakeLists.txt
+++ b/splined_voronoi/splined_voronoi/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(splined_voronoi
   # ${TINYSPLINECXX_LIBRARIES}
   ${NLOPT_LIBRARIES}
 )
-add_dependencies(splined_voronoi ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
+add_dependencies(splined_voronoi splined_voronoi_generate_messages_cpp ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 
 # ##########

--- a/splined_voronoi/splined_voronoi/README.md
+++ b/splined_voronoi/splined_voronoi/README.md
@@ -4,7 +4,7 @@ This Package contains a global path planner for multi robot formations based on 
 
 ## Installation
 
-Need tinyspline and nlopt built from source which are contained as git submodules
+Need nlopt built from source which is contained as git submodules
 
 ```bash
 cd path/to/match_path_planning
@@ -16,15 +16,6 @@ cd build
 cmake ..
 make
 sudo make install
-
-cd path/to/match_path_planning
-cd splined_voronoi
-cd tinyspline
-mkdir build
-cd build
-cmake -DBUILD_SHARED_LIBS=True ..
-cmake --build .
-sudo cmake --build . --target install
 ```
 
 Install dependencies from rosdep:

--- a/splined_voronoi/splined_voronoi/config/SplinedVoronoiPlanner.cfg
+++ b/splined_voronoi/splined_voronoi/config/SplinedVoronoiPlanner.cfg
@@ -14,6 +14,7 @@ gen.add("angle_threshold", double_t, 0, "Minimum angle between two control point
 gen.add("max_optimization_time", double_t, 0, "Maximum time after which optimization is forced to fail", 4.0, 1.0, 30.0)
 
 gen.add("optimize_lengths", bool_t, 0, "Toggle if tangent lengths are also optimized", True)
+gen.add("perform_splining", bool_t, 0, "Toggle if path is splined", True)
 
 
 exit(gen.generate(PACKAGE, "splined_voronoi", "SplinedVoronoiPlanner"))

--- a/splined_voronoi/splined_voronoi/config/splined_voronoi_params.yaml
+++ b/splined_voronoi/splined_voronoi/config/splined_voronoi_params.yaml
@@ -12,6 +12,7 @@ SplinedVoronoiPlanner:
   free_space_factor: 4.0
   optimize_lengths: true
   max_optimization_time: 4.0
+  perform_splining: false
 
   formation_config:
     robot_names: ["/mir1", "/mir2"]

--- a/splined_voronoi/splined_voronoi/include/splined_voronoi/path_smoothing.h
+++ b/splined_voronoi/splined_voronoi/include/splined_voronoi/path_smoothing.h
@@ -43,6 +43,7 @@ typedef struct {
     double default_length;
     bool was_terminated;
     std::vector<double>& best_result;
+    const std::vector<int>& optimize_lengths_indices;
 } specific_points_optim_data;
 
 /**

--- a/splined_voronoi/splined_voronoi/include/splined_voronoi/path_smoothing.h
+++ b/splined_voronoi/splined_voronoi/include/splined_voronoi/path_smoothing.h
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <numeric>
 #include <chrono>
-#include <tinysplinecxx.h>
+// #include <tinysplinecxx.h>
 #include <nlopt.hpp>
 #include <ros/ros.h>
 #include <geometry_msgs/PoseStamped.h>

--- a/splined_voronoi/splined_voronoi/include/splined_voronoi/splined_voronoi_planner.h
+++ b/splined_voronoi/splined_voronoi/include/splined_voronoi/splined_voronoi_planner.h
@@ -102,6 +102,7 @@ public:
 private:
     bool initialized_;
     bool optimize_lengths_;
+    bool perform_splining_;
     std::shared_ptr<costmap_2d::Costmap2D> costmap_;
     std::string costmap_global_frame_;
     cv::Point2d map_origin_;

--- a/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
+++ b/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
@@ -640,11 +640,9 @@ double combinedMinFunction(const std::vector<double> &x, std::vector<double> &gr
     std::vector<std::vector<cv::Point2d>> control_points_path;
     calcControlPointsForPath(points_orig_replaced, lengths, control_points_path, optim_data->default_length);
 
-    double max_cost;
-    double max_curvature;
+    double max_cost = 0;
+    double max_curvature = 0;
     maxCostAndCurvatureFromSpline(control_points_path, *optim_data, max_curvature, max_cost);
-    max_cost += 254.0;
-    max_curvature += optim_data->curvature_limit;
     // end of new part
 
 
@@ -675,6 +673,7 @@ double combinedMinFunction(const std::vector<double> &x, std::vector<double> &gr
     double total_time_in_optimization = (std::chrono::duration_cast<std::chrono::microseconds>(end_min_func - optim_data->start_time).count()) / 1000000.0;
     if (total_time_in_optimization > optim_data->time_limit)
     {
+        ROS_INFO_STREAM("Last vals before aborting: " << max_cost << ", " << max_curvature);
         optim_data->was_terminated = false;
         throw nlopt::forced_stop();
     }

--- a/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
+++ b/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
@@ -425,7 +425,7 @@ void get_optimize_indices(const std::vector<cv::Point2d>& points, const std::vec
             */
         }
     }
-    optimize_lengths_indices.push_back(control_points_path.size());
+    // optimize_lengths_indices.push_back(control_points_path.size());
 }
 
 
@@ -582,10 +582,11 @@ void maxCostAndCurvatureFromSpline(const std::vector<std::vector<cv::Point2d>>& 
     int map_size_x = optim_data.costmap.getSizeInCellsX();
     int map_size_y = optim_data.costmap.getSizeInCellsY();
     double map_resolution = optim_data.costmap.getResolution();
+    cv::Point2i last_point_map(-1,-1);
     for (auto control_points: control_points_path)
     {
         double eps = 0.0001;
-        for (double t = eps; t <= 1; t += 1. / 200.0)
+        for (double t = eps; t <= 1; t += 1. / 500.0)
         {
             cv::Point2d c = interpolate_spline(control_points, t);
             cv::Point2d cp = interpolate_spline_der(control_points, t);
@@ -597,6 +598,11 @@ void maxCostAndCurvatureFromSpline(const std::vector<std::vector<cv::Point2d>>& 
             }
             cv::Point2i point_map;
             worldToMap(c, point_map, map_origin, map_size_x, map_size_y, map_resolution);
+            if (point_map.x == last_point_map.x && point_map.y == last_point_map.y)
+            {
+                continue;
+            }
+            last_point_map = point_map;
             double pixel_cost = optim_data.costmap_img.at<float>(point_map.x, point_map.y);
             if (pixel_cost > max_cost)
             {

--- a/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
+++ b/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
@@ -315,7 +315,7 @@ cv::Mat buildCostmapImg(const cv::Mat& img)
     cv::distanceTransform(~img, costmap_img, cv::DIST_L2, 3, CV_8UC1);
     // cv::imwrite("/home/rosmatch/Bilder/dists.png", costmap_img);
     cv::Mat combined_costmap_img;
-    cv::add(img, 255 - costmap_img, combined_costmap_img, cv::noArray(), CV_8UC1);
+    cv::add(img, 254 - costmap_img, combined_costmap_img, cv::noArray(), CV_8UC1);
     // cv::imwrite("/home/rosmatch/Bilder/costmap_img_dist.png", combined_costmap_img);
     cv::Mat costmap_img_inside_obstacles;
     cv::distanceTransform(img, costmap_img_inside_obstacles, cv::DIST_L2, 3);

--- a/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
+++ b/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
@@ -586,7 +586,7 @@ void maxCostAndCurvatureFromSpline(const std::vector<std::vector<cv::Point2d>>& 
     for (auto control_points: control_points_path)
     {
         double eps = 0.0001;
-        for (double t = eps; t <= 1; t += 1. / 500.0)
+        for (double t = eps; t < 1; t += 1. / 200.0)
         {
             cv::Point2d c = interpolate_spline(control_points, t);
             cv::Point2d cp = interpolate_spline_der(control_points, t);

--- a/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
+++ b/splined_voronoi/splined_voronoi/src/path_smoothing.cpp
@@ -189,62 +189,102 @@ bool calcControlPointsForPath(const std::vector<cv::Point2d>& points, const std:
     return true;
 }
 
-tinyspline::BSpline buildTinyspline(std::vector<cv::Point2d> control_points)
+
+cv::Point2d interpolate_spline(const std::vector<cv::Point2d>& control_points, double fraction)
 {
-    // ROS_INFO("Building spline");
-    tinyspline::BSpline spline(6, 2, 5);
-    // Setup control points. They are stored as x0, y0, x1, y1, x2, y2, etc.
-    std::vector<tinyspline::real> ctrlp = spline.controlPoints();
-    ctrlp[0] = (tsReal)control_points.at(0).x;
-    ctrlp[1] = (tsReal)control_points.at(0).y;
-    ctrlp[2] = (tsReal)control_points.at(1).x;
-    ctrlp[3] = (tsReal)control_points.at(1).y;
-    ctrlp[4] = (tsReal)control_points.at(2).x;
-    ctrlp[5] = (tsReal)control_points.at(2).y;
-    ctrlp[6] = (tsReal)control_points.at(3).x;
-    ctrlp[7] = (tsReal)control_points.at(3).y;
-    ctrlp[8] = (tsReal)control_points.at(4).x;
-    ctrlp[9] = (tsReal)control_points.at(4).y;
-    ctrlp[10] = (tsReal)control_points.at(5).x;
-    ctrlp[11] = (tsReal)control_points.at(5).y;
-    spline.setControlPoints(ctrlp);
-    return spline;
+    cv::Point2d p_0(control_points.at(0));
+    cv::Point2d p_1(control_points.at(1));
+    cv::Point2d p_2(control_points.at(2));
+    cv::Point2d p_3(control_points.at(3));
+    cv::Point2d p_4(control_points.at(4));
+    cv::Point2d p_5(control_points.at(5));
+    cv::Point2d c_qb_0 = -p_0 + 5 * p_1 - 10 * p_2 + 10 * p_3 - 5 * p_4 + p_5;
+    cv::Point2d c_qb_1 = 5 * p_0 - 20 * p_1 + 30 * p_2 - 20 * p_3 + 5 * p_4;
+    cv::Point2d c_qb_2 = -10 * p_0 + 30 * p_1 - 30 * p_2 + 10 * p_3;
+    cv::Point2d c_qb_3 = 10 * p_0 - 20 * p_1 + 10 * p_2;
+    cv::Point2d c_qb_4 = -5 * p_0 + 5 * p_1;
+    cv::Point2d c_qb_5 = p_0;
+    cv::Point2d out_sample = pow(fraction, 5) * c_qb_0 + pow(fraction, 4) * c_qb_1 + pow(fraction, 3) * c_qb_2 + pow(fraction, 2) * c_qb_3 + fraction * c_qb_4 + c_qb_5;
+    return out_sample;
 }
 
 
-double calcTinysplineLength(const tinyspline::BSpline& spline)
+cv::Point2d interpolate_spline_der(const std::vector<cv::Point2d>& control_points, double fraction)
+{
+    cv::Point2d p_0(control_points.at(0));
+    cv::Point2d p_1(control_points.at(1));
+    cv::Point2d p_2(control_points.at(2));
+    cv::Point2d p_3(control_points.at(3));
+    cv::Point2d p_4(control_points.at(4));
+    cv::Point2d p_5(control_points.at(5));
+    cv::Point2d c_qb_0 = -p_0 + 5 * p_1 - 10 * p_2 + 10 * p_3 - 5 * p_4 + p_5;
+    cv::Point2d c_qb_1 = 5 * p_0 - 20 * p_1 + 30 * p_2 - 20 * p_3 + 5 * p_4;
+    cv::Point2d c_qb_2 = -10 * p_0 + 30 * p_1 - 30 * p_2 + 10 * p_3;
+    cv::Point2d c_qb_3 = 10 * p_0 - 20 * p_1 + 10 * p_2;
+    cv::Point2d c_qb_4 = -5 * p_0 + 5 * p_1;
+    cv::Point2d c_qb_5 = p_0;
+    cv::Point2d out_sample = 5 * pow(fraction, 4) * c_qb_0 + 4 * pow(fraction, 3) * c_qb_1 + 3 * pow(fraction, 2) * c_qb_2 + 2 * fraction * c_qb_3 + c_qb_4;
+    return out_sample;
+}
+
+cv::Point2d interpolate_spline_der2(const std::vector<cv::Point2d>& control_points, double fraction)
+{
+    cv::Point2d p_0(control_points.at(0));
+    cv::Point2d p_1(control_points.at(1));
+    cv::Point2d p_2(control_points.at(2));
+    cv::Point2d p_3(control_points.at(3));
+    cv::Point2d p_4(control_points.at(4));
+    cv::Point2d p_5(control_points.at(5));
+    cv::Point2d c_qb_0 = -p_0 + 5 * p_1 - 10 * p_2 + 10 * p_3 - 5 * p_4 + p_5;
+    cv::Point2d c_qb_1 = 5 * p_0 - 20 * p_1 + 30 * p_2 - 20 * p_3 + 5 * p_4;
+    cv::Point2d c_qb_2 = -10 * p_0 + 30 * p_1 - 30 * p_2 + 10 * p_3;
+    cv::Point2d c_qb_3 = 10 * p_0 - 20 * p_1 + 10 * p_2;
+    cv::Point2d c_qb_4 = -5 * p_0 + 5 * p_1;
+    cv::Point2d c_qb_5 = p_0;
+    cv::Point2d out_sample = 20 * pow(fraction, 3) * c_qb_0 + 12 * pow(fraction, 2) * c_qb_1 + 6 * fraction * c_qb_2 + 2 * c_qb_3;
+    return out_sample;
+}
+
+bool sample_spline(const std::vector<cv::Point2d>& control_points, std::vector<cv::Point2d>& out_samples, int num_samples)
+{
+    for (int idx = 0; idx < num_samples; idx++)
+    {
+        double frac = (double)idx / (double)num_samples;
+        out_samples.push_back(interpolate_spline(control_points, frac));
+    }
+    return true;
+}
+
+double calcSplineLength(const std::vector<cv::Point2d>& control_points)
 {
     int num_samples = 100;
-    std::vector<tinyspline::real> sampled_points_for_length = spline.sample(num_samples);
+    std::vector<cv::Point2d> sampled_points_for_length;
+    sample_spline(control_points, sampled_points_for_length, num_samples);
     double spline_length = 0.0;
-    for (int index_x = 2; index_x < sampled_points_for_length.size() - 1; index_x += 2)
+    for (int idx = 1; idx < sampled_points_for_length.size(); idx++)
     {
-        int index_y = index_x + 1;
-        double x_val = sampled_points_for_length.at(index_x);
-        double y_val = sampled_points_for_length.at(index_y);
-        double last_x_val = sampled_points_for_length.at(index_x - 2);
-        double last_y_val = sampled_points_for_length.at(index_y - 2);
-        double segdist = sqrt(pow(x_val - last_x_val, 2) + pow(y_val - last_y_val, 2));
+        cv::Point2d curr_sample = sampled_points_for_length.at(idx);
+        cv::Point2d last_sample = sampled_points_for_length.at(idx - 1);
+        cv::Point2d diff = curr_sample - last_sample;
+        double segdist = sqrt(pow(diff.x, 2) + pow(diff.y, 2));
         spline_length += segdist;
     }
     return spline_length;
 }
 
-void equidistantSampling(const tinyspline::BSpline& spline, double sample_distance, std::vector<cv::Point2d>& samples)
+void equidistantSampling(const std::vector<cv::Point2d>& control_points, double sample_distance, std::vector<cv::Point2d>& samples)
 {
     samples.clear();
-    double spline_length = calcTinysplineLength(spline);
-    tinyspline::Vec2 last_sample = spline(0).resultVec2();
+    double spline_length = calcSplineLength(control_points);
+    cv::Point2d last_sample = interpolate_spline(control_points, 0);
     int num_samples = (int) 10 * spline_length / sample_distance;
     for (double frac = 0.0; frac <= 1; frac+=1.0/(double)num_samples)
     {
-        tinyspline::Vec2 sample = spline(frac).resultVec2();
-        tinyspline::Vec2 diff = sample - last_sample;
-        if (diff.magnitude() > sample_distance)
+        cv::Point2d sample = interpolate_spline(control_points, frac);
+        cv::Point2d diff = sample - last_sample;
+        if (sqrt(pow(diff.x, 2) + pow(diff.y, 2)) > sample_distance)
         {
-            double x_val = sample.x();
-            double y_val = sample.y();
-            samples.push_back(cv::Point2d(x_val, y_val));
+            samples.push_back(sample);
             last_sample = sample;
         }
     }
@@ -262,13 +302,11 @@ void getSplinePathSamples(const std::vector<cv::Point2d>& points, std::vector<do
 
     for (auto control_points: control_points_path)
     {
-        tinyspline::BSpline spline = buildTinyspline(control_points);
         std::vector<cv::Point2d> samples_seg;
-        equidistantSampling(spline, sample_distance, samples_seg);
+        equidistantSampling(control_points, sample_distance, samples_seg);
         points_out.insert(points_out.end(), samples_seg.begin(), samples_seg.end());
     }
 }
-
 
 cv::Mat buildCostmapImg(const cv::Mat& img)
 {
@@ -290,30 +328,26 @@ cv::Mat buildCostmapImg(const cv::Mat& img)
     return costmap_img_inside_obstacles;
 }
 
-
-std::vector<double> tinysplineCurvatures(const tinyspline::BSpline& spline, int num_samples = 1000)
+std::vector<double> splineCurvatures(const std::vector<cv::Point2d>& control_points, int num_samples = 1000)
 {
     // ROS_INFO("Calculating curvatures");
-    tinyspline::BSpline spline_deriv = spline.derive();
-    tinyspline::BSpline spline_deriv2 = spline_deriv.derive();
     std::vector<double> curvatures;
     double eps = 0.0001;
-    for (double t = 0; t <= 1; t += 1. / (double)num_samples)
+    for (double t = eps; t <= 1; t += 1. / (double)num_samples)
     {
-        tinyspline::Vec3 cp = spline_deriv(t).resultVec3();
-        tinyspline::Vec3 cpp = spline_deriv2(t).resultVec3();
-        double curvature = abs((cp.x() * cpp.y() - cpp.x() * cp.y())/ pow(pow(cp.x(), 2) + pow(cp.y(), 2), 1.5));
+        cv::Point2d cp = interpolate_spline_der(control_points, t);
+        cv::Point2d cpp = interpolate_spline_der2(control_points, t);
+        double curvature = abs((cp.x * cpp.y - cpp.x * cp.y)/ pow(pow(cp.x, 2) + pow(cp.y, 2), 1.5));
         curvatures.push_back(curvature);
     }
     return curvatures;
 }
 
-
-double maxCostOfSpline(const tinyspline::BSpline& spline, const costmap_2d::Costmap2D& costmap, const cv::Mat& costmap_img)
+double maxCostOfSpline(const std::vector<cv::Point2d>& control_points, const costmap_2d::Costmap2D& costmap, const cv::Mat& costmap_img)
 {
     double sample_distance = 0.02;
     std::vector<cv::Point2d> samples;
-    equidistantSampling(spline, sample_distance, samples);
+    equidistantSampling(control_points, sample_distance, samples);
     std::vector<cv::Point2i> samples_map;
     pathWorldToMap(samples, samples_map, std::make_shared<costmap_2d::Costmap2D>(costmap));
     double max_cost = 0.0;
@@ -343,10 +377,9 @@ void get_optimize_indices(const std::vector<cv::Point2d>& points, const std::vec
     for (int idx = 0; idx < control_points_path.size(); idx++)
     {
         std::vector<cv::Point2d> control_points = control_points_path.at(idx);
-        tinyspline::BSpline spline = buildTinyspline(control_points);
-        std::vector<double> curvatures = tinysplineCurvatures(spline, 200);
+        std::vector<double> curvatures = splineCurvatures(control_points, 200);
         double max_curvature = *std::max_element(curvatures.begin(), curvatures.end());
-        double max_cost_seg = maxCostOfSpline(spline, costmap, costmap_img);
+        double max_cost_seg = maxCostOfSpline(control_points, costmap, costmap_img);
         if (max_curvature > curve_max)
         {
             optimize_indices.push_back(idx + 1);
@@ -456,8 +489,7 @@ double maxCostOfPath(const std::vector<double> &x, std::vector<double> &grad, vo
         {
             // continue;
         }
-        tinyspline::BSpline spline = buildTinyspline(control_points);
-        double max_cost_seg = maxCostOfSpline(spline, constraint_data->costmap, constraint_data->costmap_img);
+        double max_cost_seg = maxCostOfSpline(control_points, constraint_data->costmap, constraint_data->costmap_img);
         if (max_cost_seg > max_cost)
         {
             max_cost = max_cost_seg;
@@ -517,8 +549,7 @@ double maxCurvatureFromPoints(const std::vector<double> &x, std::vector<double> 
         {
             // continue;
         }
-        tinyspline::BSpline spline = buildTinyspline(control_points);
-        std::vector<double> curvatures = tinysplineCurvatures(spline, 200);
+        std::vector<double> curvatures = splineCurvatures(control_points, 200);
         double max_curvature_seg = *std::max_element(curvatures.begin(), curvatures.end());
         if (max_curvature_seg > max_curvature)
         {

--- a/splined_voronoi/splined_voronoi/src/splined_voronoi_planner.cpp
+++ b/splined_voronoi/splined_voronoi/src/splined_voronoi_planner.cpp
@@ -337,7 +337,7 @@ bool SplinedVoronoiPlanner::makePlan(const geometry_msgs::PoseStamped& start, co
 
     // get areas with large freespaces and overly voronoi diagram with it
     cv::Mat costmap_large_spaces;
-    cv::threshold(costmap_img_orig, costmap_large_spaces, this->free_space_factor_  / this->costmap_resolution_, 255, cv::THRESH_BINARY);
+    cv::threshold(costmap_dist_img, costmap_large_spaces, this->free_space_factor_  / this->costmap_resolution_, 255, cv::THRESH_BINARY);
     costmap_large_spaces.convertTo(costmap_large_spaces, CV_8UC1);
     cv::bitwise_or(this->voronoi_img_, costmap_large_spaces, this->voronoi_img_);
 

--- a/splined_voronoi/splined_voronoi/src/splined_voronoi_planner.cpp
+++ b/splined_voronoi/splined_voronoi/src/splined_voronoi_planner.cpp
@@ -56,6 +56,7 @@ void SplinedVoronoiPlanner::initialize(std::string name, costmap_2d::Costmap2DRO
         private_nh.param("max_optimization_time", max_optimization_time_, 4.0);
         private_nh.param("free_space_factor", this->free_space_factor_, 4.0);
         private_nh.param("optimize_lengths", optimize_lengths_, false);
+        private_nh.param("perform_splining", this->perform_splining_, true);
         ROS_INFO_STREAM("Load param free_cell_threshold: " << free_cell_threshold_);
         ROS_INFO_STREAM("Load param angle_threshold: " << angle_threshold_);
         ROS_INFO_STREAM("Load param min_distance_control_points: " << min_distance_control_points_m_);
@@ -140,6 +141,7 @@ void SplinedVoronoiPlanner::reconfigureCB(splined_voronoi::SplinedVoronoiPlanner
     this->min_distance_control_points_m_ = config.min_distance_control_points;
     this->max_optimization_time_ = config.max_optimization_time;
     this->free_space_factor_ = config.free_space_factor;
+    this->perform_splining_ = config.perform_splining;
     ROS_INFO_STREAM("Max curvature is now: " << this->max_curvature_);
 }
 
@@ -280,7 +282,6 @@ bool SplinedVoronoiPlanner::makePlan(const geometry_msgs::PoseStamped& start, co
             if (cell_cost != costmap_2d::NO_INFORMATION && cell_cost > free_cell_threshold_)
             {
                 costmap_img_wo_unknowns.at<uchar>(i, j, 0) = 255;
-                unknown_counter++;
             }
             if (cell_cost > free_cell_threshold_)
             {
@@ -395,17 +396,27 @@ bool SplinedVoronoiPlanner::makePlan(const geometry_msgs::PoseStamped& start, co
         // for an empty path return a plan from start to goal, otherwise dont include start to begin plan on voronoi
         path.insert(path.begin(), this->start_map_);
     }
-    
-    // select waypoints from path
-    double min_distance_control_points_px = this->min_distance_control_points_m_ / this->costmap_resolution_;
-    std::vector<cv::Point2i> sparse_path;
-    bool sparse_success = path_planning::sparsify_path(path, sparse_path, this->angle_threshold_, min_distance_control_points_px);
 
     // create unreduced plan for debug output
     std::vector<geometry_msgs::PoseStamped> unreduced_plan;
     path_planning::createPlanFromPath(path, unreduced_plan, this->costmap_, this->costmap_global_frame_);
     this->astar_path_ = unreduced_plan;
     this->publishPlan(unreduced_plan, this->original_plan_pub_);
+
+    if(!perform_splining_)
+    {
+        // return unsplined path
+        for (auto pose : unreduced_plan)
+        {
+            plan.push_back(pose);
+        }
+        return true;
+    }
+
+    // select waypoints from path
+    double min_distance_control_points_px = this->min_distance_control_points_m_ / this->costmap_resolution_;
+    std::vector<cv::Point2i> sparse_path;
+    bool sparse_success = path_planning::sparsify_path(path, sparse_path, this->angle_threshold_, min_distance_control_points_px);
 
     // create sparse plan for debug output
     std::vector<geometry_msgs::PoseStamped> sparse_plan;


### PR DESCRIPTION
restructuring mainly of path smoothing:
- remove tinyspline dependency and implement needed functions for spline sampling by hand
- only sample spline once in minimize function therefore much faster calculation
- only optimize relevant tangent length for less parameters in optimization 